### PR TITLE
Support for Cordova Android 7.0.0 projects

### DIFF
--- a/hooks/lib/android/manifestWriter.js
+++ b/hooks/lib/android/manifestWriter.js
@@ -20,6 +20,11 @@ module.exports = {
 function writePreferences(cordovaContext, pluginPreferences) {
   var pathToManifest = path.join(cordovaContext.opts.projectRoot, 'platforms', 'android', 'AndroidManifest.xml');
   var manifestSource = xmlHelper.readXmlAsJson(pathToManifest);
+  if (manifestSource === undefined) {
+    // try Cordova Android 7 project location
+    pathToManifest = path.join(cordovaContext.opts.projectRoot, 'platforms', 'android', 'app','src','main','AndroidManifest.xml');
+    manifestSource = xmlHelper.readXmlAsJson(pathToManifest);
+  }
   var cleanManifest;
   var updatedManifest;
 


### PR DESCRIPTION
The  AndroidManifest.xml location has moved with the new file structure. This change will look for the file in both locations